### PR TITLE
do not need to loaded content form in document type UI

### DIFF
--- a/OP10.MultipleMediaPicker/App_Plugins/OP10.MultipleMediaPicker/op10.multipleMediaPicker.controller.js
+++ b/OP10.MultipleMediaPicker/App_Plugins/OP10.MultipleMediaPicker/op10.multipleMediaPicker.controller.js
@@ -8,8 +8,10 @@
 	function multipleMediaPickerController($scope, $q, umbPropEditorHelper, dialogService, entityResource, mediaResource, mediaHelper, multipleMediaPickerResource, notificationsService, $timeout) {
 
 		// get the content item form
-		$scope.contentForm = angular.element('form[name=contentForm]').scope().contentForm;
-
+	    var contentForm = angular.element('form[name=contentForm]').scope();
+	    if (contentForm != undefined) {
+	        $scope.contentForm = contentForm.contentForm;
+	    }
 		//check the pre-values for multi-picker
 		var multiPicker = $scope.model.config.multiPicker && $scope.model.config.multiPicker !== '0' ? true : false;
 


### PR DESCRIPTION
Since Umbraco has introduced a new UI for document types, a angular error blocks rendering of a document type layout that contains an OP multiple media picker property.
