### PR TITLE
fix: changed valuetype from string to text

### DIFF
--- a/OP10.MultipleMediaPicker/App_Plugins/OP10.MultipleMediaPicker/package.manifest
+++ b/OP10.MultipleMediaPicker/App_Plugins/OP10.MultipleMediaPicker/package.manifest
@@ -4,7 +4,7 @@
 		"name":  "OP10 Multiple Media Picker",
 			"editor": {
 				"view": "~/App_Plugins/OP10.MultipleMediaPicker/multipleMediaPicker.html?v=ASSEMBLY_VERSION",
-				"valueType": "STRING"
+				"valueType": "TEXT"
 			},
 		"prevalues": {
 			"fields": [


### PR DESCRIPTION
When you have a lot of medias selected it would throw an sql exception that the string would be truncated.

With valuetype `text` it saves the value in the column `dataNtext(NText`) instead of `dataNvarchar (nvarchar(500))`.