### PR TITLE
legacy id migration

### DIFF
--- a/OP10.MultipleMediaPicker/PropertyEditors/ValueConverters/OP10MultipleMediaPickerPropertyConverter.cs
+++ b/OP10.MultipleMediaPicker/PropertyEditors/ValueConverters/OP10MultipleMediaPickerPropertyConverter.cs
@@ -63,7 +63,6 @@ namespace OP10.MultipleMediaPicker.PropertyEditors.ValueConverters
 		{
 			var nodeIds = source.ToString()
 				.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries)
-				.Select(Udi.Parse)
 				.ToArray();
 			return nodeIds;
 		}
@@ -90,18 +89,28 @@ namespace OP10.MultipleMediaPicker.PropertyEditors.ValueConverters
 				return null;
 			}
 
-			var udis = (Udi[])source;
+			var ids = (string[])source;
 			var mediaItems = new List<IPublishedContent>();
 			if (UmbracoContext.Current == null) return source;
 			var helper = new UmbracoHelper(UmbracoContext.Current);
 
-			if (udis.Any())
+			if (ids.Any())
 			{
-				foreach (var udi in udis)
+				foreach (var id in ids)
 				{
-					var item = helper.TypedMedia(udi);
+					IPublishedContent item = null;
+					if (Udi.TryParse(id, out Udi udi))
+					{
+						item = helper.TypedMedia(udi);
+					}
+					else if (int.TryParse(id, out int legacyId))
+					{
+						item = helper.TypedMedia(legacyId);
+					}
 					if (item != null)
+					{
 						mediaItems.Add(item);
+					}
 				}
 				if (IsMultipleDataType(propertyType.DataTypeId, propertyType.PropertyEditorAlias))
 				{


### PR DESCRIPTION
This fix checks if the saved ids are in new UDI or old ID format and gets the content from the cache by old integer id if it cannot be converted to new UDI format.
